### PR TITLE
Include in-flight tool names in timeout error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -237,6 +237,8 @@ export async function createSandbox(options: SandboxOptions): Promise<Sandbox> {
 		const pendingQjsPromises: {promise: ReturnType<typeof vm.newPromise>; settled: boolean}[] = [];
 		// Mutable ref to main promise handle - used by resolve callbacks to check if main promise is done
 		const mainPromiseRef: {handle: ReturnType<typeof vm.newPromise>['handle'] | null} = {handle: null};
+		// Track in-flight tool calls for better timeout error messages
+		const inFlightToolCalls = new Set<string>();
 
 		// Set up interrupt handler to stop execution after main promise fulfills
 		// This prevents abandoned Promise.race callbacks from running
@@ -311,9 +313,11 @@ export async function createSandbox(options: SandboxOptions): Promise<Sandbox> {
 				pendingQjsPromises.push(promiseEntry);
 
 				const asyncWork = (async () => {
+					inFlightToolCalls.add(toolName);
 					const tool = tools.find((t) => t.name === toolName);
 
 					if (!tool) {
+						inFlightToolCalls.delete(toolName);
 						resolveQueue = resolveQueue.then(() => {
 							if (vmDisposed || mainPromiseFulfilled) {
 								return;
@@ -334,6 +338,7 @@ export async function createSandbox(options: SandboxOptions): Promise<Sandbox> {
 					try {
 						options.onBeforeToolCall?.(beforeEvent);
 					} catch (err) {
+						inFlightToolCalls.delete(toolName);
 						resolveQueue = resolveQueue.then(() => {
 							if (vmDisposed || mainPromiseFulfilled) {
 								return;
@@ -351,6 +356,7 @@ export async function createSandbox(options: SandboxOptions): Promise<Sandbox> {
 
 					// Check if returnValue was set
 					if ('returnValue' in beforeEvent) {
+						inFlightToolCalls.delete(toolName);
 						const successEvent: ToolCallSuccessEvent = {
 							toolName,
 							args,
@@ -388,6 +394,7 @@ export async function createSandbox(options: SandboxOptions): Promise<Sandbox> {
 					// Call the tool with potentially modified args
 					try {
 						const result = await tool.handler(beforeEvent.args);
+						inFlightToolCalls.delete(toolName);
 
 						const successEvent: ToolCallSuccessEvent = {
 							toolName, args, result,
@@ -419,6 +426,7 @@ export async function createSandbox(options: SandboxOptions): Promise<Sandbox> {
 							checkMainPromiseDone();
 						});
 					} catch (err) {
+						inFlightToolCalls.delete(toolName);
 						const error = err instanceof Error ? err : new Error(String(err));
 
 						const errorEvent: ToolCallErrorEvent = {
@@ -515,7 +523,11 @@ export async function createSandbox(options: SandboxOptions): Promise<Sandbox> {
 				if (pollIterations >= maxPollIterations) {
 					promiseHandle.dispose();
 					storeHandle.dispose();
-					return {success: false, error: 'Execution timed out', blobs: Array.from(blobStore.values())};
+					const inFlight = Array.from(inFlightToolCalls);
+					const error = inFlight.length > 0
+						? `Execution timed out while waiting for tool call(s): ${inFlight.join(', ')}`
+						: 'Execution timed out';
+					return {success: false, error, blobs: Array.from(blobStore.values())};
 				}
 			}
 


### PR DESCRIPTION
## Summary

- When execution times out, the error message now includes which tool call(s) were still pending
- Before: `Execution timed out`
- After: `Execution timed out while waiting for tool call(s): chrome__navigate_page`

## Context

When a tool call blocks indefinitely (e.g. Chrome DevTools tools hanging because a native dialog is blocking the browser), the sandbox times out with a generic "Execution timed out" message. This gives the model no information about what went wrong, leading to blind retries instead of targeted fixes (like using a different tool to dismiss the blocking dialog).

## Implementation

Tracks in-flight tool calls in a `Set<string>`, adding the tool name when a call starts and removing it when it resolves/rejects. On timeout, any remaining entries are included in the error message.

## Test plan

- [x] All 55 existing tests pass
- [ ] Verify timeout error includes tool name when a tool call is the blocker

🤖 Generated with [Claude Code](https://claude.com/claude-code)