### PR TITLE
Clarify list_tools return format in description

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -184,7 +184,7 @@ export async function createSandbox(options: SandboxOptions): Promise<Sandbox> {
 	// Add built-in list_tools tool
 	const listToolsTool: Tool = {
 		name: 'list_tools',
-		description: 'List all available tools',
+		description: 'List all available tools. Returns an array of {name, description} objects.',
 		inputSchema: {type: 'object', properties: {}},
 		async handler() {
 			return tools.map((t) => ({name: t.name, description: t.description}));


### PR DESCRIPTION
## Summary

- Documents that `list_tools` returns an array of `{name, description}` objects in the tool description
- Prevents models from guessing the wrong return shape (e.g. trying `.result.filter(...)` or treating items as strings)

## Test plan

- [x] All 55 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)